### PR TITLE
Added pycrypto to install

### DIFF
--- a/sensor.sh
+++ b/sensor.sh
@@ -14,6 +14,7 @@ if [ -f /etc/debian_version ]; then
     apt-get -y update
     apt-get -y install python-dev python-openssl python-pyasn1 authbind git python-pip libcurl4-gnutls-dev libssl-dev
     pip install pycurl
+    pip install pycrypto
     pip install service_identity
     pip install ipwhois
 elif [ -f /etc/redhat-release ]; then


### PR DESCRIPTION
twistd failed to load on Ubuntu 14.04 without this package installed.