### PR TITLE
inputs.conf - change kippolog.json* to kippo.json* 

### DIFF
--- a/tango_input/default/inputs.conf
+++ b/tango_input/default/inputs.conf
@@ -1,4 +1,4 @@
-[monitor:///opt/kippo/log/kippolog.json*]
+[monitor:///opt/kippo/log/kippo.json*]
 disabled = false
 index = honeypot
 sourcetype = kippojson


### PR DESCRIPTION
Change [monitor:///opt/kippo/log/kippolog.json] to [monitor:///opt/kippo/log/kippo.json] in inputs.conf

When using micheloosterhof's kippo https://github.com/micheloosterhof/kippo,
the name of the json file is kippo.json in /opt/kippo/log/