### PR TITLE
use cowrie user to chmod the log

### DIFF
--- a/sensor.sh
+++ b/sensor.sh
@@ -322,7 +322,7 @@ sed -i "s/test/$SPLUNK_INDEXER/" outputs.conf &>> $logfile
 chown -R splunk:splunk /opt/splunkforwarder &>> $logfile
 /opt/splunkforwarder/bin/splunk restart &>> $logfile
 error_check 'Tango_input installation'
-chmod 777 /opt/cowrie/log/cowrie.json
+sudo -u cowrie chmod 777 /opt/cowrie/log/cowrie.json
 
 print_notification "If the location of your kippo log files changes or the hostname/ip of the indexer changes, you will need to modify /opt/splunkfowarder/etc/apps/tango_input/default/inputs.conf and outputs.conf respectively."
 


### PR DESCRIPTION
We ran into problems with this line where the splunk instance was showing a sensor online but no information was being gathered.  On AWS EC2 the fix was to sudo, but I since the owner of the file is cowrie that the change submitted is useful.